### PR TITLE
logs the quarto version to the build log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ export async function onPreBuild({
   console.log('Netlify configuration', netlifyConfig)
   console.log('Plugin configuration', inputs)
   console.log('Build directory', PUBLISH_DIR)
-  console.log('Quarto version', quartoVersion)
+  console.log('Quarto version', asset)
 
   // Display success information
   status.show({ summary: 'Success!' })

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ export async function onPreBuild({
   console.log('Netlify configuration', netlifyConfig)
   console.log('Plugin configuration', inputs)
   console.log('Build directory', PUBLISH_DIR)
+  console.log('Quarto version', quartoVersion)
 
   // Display success information
   status.show({ summary: 'Success!' })


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

Please make sure the title is clear and descriptive.

If you are fixing a typo or documentation, please skip these instructions.

Otherwise please fill in the sections below.

**Which problem is this pull request solving?**

When building a site, the Netlify build log does not currently contain the Quarto version.

This makes it difficult to track down issues arising from differences between a user's local environment and the Netlify build environment. 

**List other issues or pull requests related to this problem**

None

**Describe the solution you've chosen**

I've fixed this by adding another `console.log` under the existing ones that dumps out the `asset` info.

**Describe alternatives you've considered**

I did consider dumping out `quartoVersion` instead, but this can often say `latest`, which is not very helpful either.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] **NA** - I have added tests (we are enforcing 100% test coverage).
- [ ] **NA** - I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [ ] The status checks are successful (continuous integration). Those can be
      seen below.
