### PR TITLE
use GITHUB_TOKEN from action env

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -2,7 +2,9 @@ import { Octokit } from '@octokit/rest'
 import { writeFile } from 'fs/promises'
 import { Buffer } from 'buffer'
 
-const octokit = new Octokit()
+const octokit = new Octokit({
+  auth: process.env.GITHUB_TOKEN
+})
 
 function findDebAsset(assets) {
   return assets.filter((asset) => {


### PR DESCRIPTION
Otherwise please fill in the sections below.

workflows relying on the netlify quarto action are failing intermittently due to being rate limited by the GitHub API.

closes #5 

**Describe the solution you've chosen**

This PR updates the Octokit instantiation to use the GitHub token provided by default to all actions

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have added tests (we are enforcing 100% test coverage).
- [x] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
